### PR TITLE
Add UIAppearance support

### DIFF
--- a/KeyKit.xcodeproj/project.pbxproj
+++ b/KeyKit.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		9A0CD6C01D12F92900281ACE /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0CD6BF1D12F92900281ACE /* UIView+Extensions.swift */; };
 		9A0CD6C21D12F99800281ACE /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0CD6C11D12F99800281ACE /* KeyboardViewController.swift */; };
 		9A2E3D011D1C05BE00BF6BC8 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2E3D001D1C05BE00BF6BC8 /* Color.swift */; };
+		9A4D9A091D479EB60003503D /* TintedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4D9A081D479EB60003503D /* TintedButton.swift */; };
 		9A74894A1D18643E00C371DA /* Click.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7489491D18643E00C371DA /* Click.swift */; };
 		9A7489511D1882FC00C371DA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A7489501D1882FC00C371DA /* Assets.xcassets */; };
 		9A910A771D142B3000909040 /* TrackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A910A761D142B3000909040 /* TrackingView.swift */; };
@@ -37,6 +38,7 @@
 		9A0CD6BF1D12F92900281ACE /* UIView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		9A0CD6C11D12F99800281ACE /* KeyboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardViewController.swift; sourceTree = "<group>"; };
 		9A2E3D001D1C05BE00BF6BC8 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
+		9A4D9A081D479EB60003503D /* TintedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TintedButton.swift; sourceTree = "<group>"; };
 		9A7489491D18643E00C371DA /* Click.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Click.swift; sourceTree = "<group>"; };
 		9A7489501D1882FC00C371DA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9A910A761D142B3000909040 /* TrackingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackingView.swift; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 		9A0CD6B51D12F8F900281ACE /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				9A4D9A081D479EB60003503D /* TintedButton.swift */,
 				9A0CD6B61D12F90300281ACE /* KeyView.swift */,
 				9A0CD6B71D12F90300281ACE /* RowView.swift */,
 				9A0CD6B81D12F90300281ACE /* FaceView.swift */,
@@ -225,6 +228,7 @@
 				9A2E3D011D1C05BE00BF6BC8 /* Color.swift in Sources */,
 				9A0CD6C01D12F92900281ACE /* UIView+Extensions.swift in Sources */,
 				9A0CD6BC1D12F90300281ACE /* FaceView.swift in Sources */,
+				9A4D9A091D479EB60003503D /* TintedButton.swift in Sources */,
 				9A0CD69E1D12F77500281ACE /* Face.swift in Sources */,
 				9A0CD6BA1D12F90300281ACE /* KeyView.swift in Sources */,
 				9A74894A1D18643E00C371DA /* Click.swift in Sources */,

--- a/KeyKit/Key.swift
+++ b/KeyKit/Key.swift
@@ -10,6 +10,12 @@ import Foundation
 
 public protocol KeyActionType {}
 
+@objc public enum KeyStyle: Int {
+    case Main
+    case Alternate
+    case Done
+}
+
 public struct Key: Equatable {
     
     public enum Label: Equatable {
@@ -31,21 +37,15 @@ public struct Key: Equatable {
         case Char(String)
     }
     
-    public enum Style {
-        case Main
-        case Alternate
-        case Done
-    }
-    
     public let label:  Label
     public let value:  Value
     public let length: Double
-    public let style:  Style
+    public let style:  KeyStyle
     
     // ----------------------------------
     //  MARK: - Init -
     //
-    public init(label: Label, value: Value, length: Double, style: Style = .Main) {
+    public init(label: Label, value: Value, length: Double, style: KeyStyle = .Main) {
         self.label  = label
         self.value  = value
         self.length = length
@@ -56,7 +56,7 @@ public struct Key: Equatable {
         self.init(label: .Char(label), value: .Char(char), length: length)
     }
     
-    public init(label: String, action: Key.Action, length: Double, style: Style = .Main) {
+    public init(label: String, action: Key.Action, length: Double, style: KeyStyle = .Main) {
         self.init(label: .Char(label), value: .Action(action), length: length, style: style)
     }
     

--- a/KeyKit/KeyView.swift
+++ b/KeyKit/KeyView.swift
@@ -25,6 +25,7 @@ public class KeyView: TintedButton {
     public let key: Key
     
     private weak var targetable: KeyTargetable?
+    private var keyColors = [String : UIColor]()
     
     // ----------------------------------
     //  MARK: - Default Styles -
@@ -32,21 +33,37 @@ public class KeyView: TintedButton {
     public override static func initialize() {
         let proxy = KeyView.appearance()
         
-        let dark  = Color.rgb(r:  50, g: 77,  b:  99)
-        let light = Color.rgb(r: 121, g: 140, b: 156)
-        let alt   = Color.rgb(r: 255, g: 255, b: 255)
+        // Key colors
         
-        proxy.setTextColor(light, forStyle: .Main,      state: .Normal)
-        proxy.setTextColor(dark,  forStyle: .Alternate, state: .Normal)
-        proxy.setTextColor(alt,   forStyle: .Done,      state: .Normal)
+        let textDark  = Color.rgb(r:  50, g: 77,  b:  99)
+        let textLight = Color.rgb(r: 121, g: 140, b: 156)
+        let textAlt   = Color.rgb(r: 255, g: 255, b: 255)
         
-        proxy.setTextColor(light, forStyle: .Main,      state: .Highlighted)
-        proxy.setTextColor(alt,   forStyle: .Alternate, state: .Highlighted)
-        proxy.setTextColor(alt,   forStyle: .Done,      state: .Highlighted)
+        proxy.setTextColor(textLight, forStyle: .Main,      state: .Normal)
+        proxy.setTextColor(textDark,  forStyle: .Alternate, state: .Normal)
+        proxy.setTextColor(textAlt,   forStyle: .Done,      state: .Normal)
         
-        proxy.setTextColor(light, forStyle: .Main,      state: .Selected)
-        proxy.setTextColor(alt,   forStyle: .Alternate, state: .Selected)
-        proxy.setTextColor(alt,   forStyle: .Done,      state: .Selected)
+        proxy.setTextColor(textLight, forStyle: .Main,      state: .Highlighted)
+        proxy.setTextColor(textAlt,   forStyle: .Alternate, state: .Highlighted)
+        proxy.setTextColor(textAlt,   forStyle: .Done,      state: .Highlighted)
+        
+        proxy.setTextColor(textLight, forStyle: .Main,      state: .Selected)
+        proxy.setTextColor(textAlt,   forStyle: .Alternate, state: .Selected)
+        proxy.setTextColor(textAlt,   forStyle: .Done,      state: .Selected)
+        
+        // Key Backgrounds
+        
+        proxy.setKeyColor(Color.rgb(r: 255, g: 255, b: 255), forStyle: .Main,      state: .Normal)
+        proxy.setKeyColor(Color.rgb(r: 196, g: 204, b: 211), forStyle: .Alternate, state: .Normal)
+        proxy.setKeyColor(Color.rgb(r:  70, g: 183, b: 204), forStyle: .Done,      state: .Normal)
+        
+        proxy.setKeyColor(Color.rgb(r: 235, g: 235, b: 235), forStyle: .Main,      state: .Highlighted)
+        proxy.setKeyColor(Color.rgb(r:  70, g: 183, b: 204), forStyle: .Alternate, state: .Highlighted)
+        proxy.setKeyColor(Color.rgb(r:  48, g: 147, b: 166), forStyle: .Done,      state: .Highlighted)
+        
+        proxy.setKeyColor(Color.rgb(r: 235, g: 235, b: 235), forStyle: .Main,      state: .Selected)
+        proxy.setKeyColor(Color.rgb(r:  70, g: 183, b: 204), forStyle: .Alternate, state: .Selected)
+        proxy.setKeyColor(Color.rgb(r:  48, g: 147, b: 166), forStyle: .Done,      state: .Selected)
     }
     
     // ----------------------------------
@@ -70,6 +87,20 @@ public class KeyView: TintedButton {
     public dynamic func textColorForStyle(style: KeyStyle, state: UIControlState) -> UIColor? {
         if self.key.style == style {
             return self.titleColorForState(state)
+        }
+        return nil
+    }
+    
+    public dynamic func setKeyColor(color: UIColor, forStyle style: KeyStyle, state: UIControlState) {
+        if self.key.style == style {
+            self.keyColors[state.key] = color
+            self.setBackgroundImage(KeyBackground.imageForColor(color), forState: state)
+        }
+    }
+    
+    public dynamic func keyColorForStyle(style: KeyStyle, state: UIControlState) -> UIColor? {
+        if self.key.style == style {
+            return self.keyColors[state.key]
         }
         return nil
     }
@@ -107,26 +138,6 @@ public class KeyView: TintedButton {
             label.numberOfLines = 1
         } else {
             fatalError("Failed to configure KeyView label style. No titleLabel found.")
-        }
-        
-        /* ---------------------------------
-         ** Set background image for style
-         */
-        switch self.key.style {
-        case .Main:
-            self.setBackgroundImage(KeyView.mainNormalImage,      forState: .Normal)
-            self.setBackgroundImage(KeyView.mainHighlightedImage, forState: .Highlighted)
-            self.setBackgroundImage(KeyView.mainSelectedImage,    forState: .Selected)
-            
-        case .Alternate:
-            self.setBackgroundImage(KeyView.alternateNormalImage,      forState: .Normal)
-            self.setBackgroundImage(KeyView.alternateHighlightedImage, forState: .Highlighted)
-            self.setBackgroundImage(KeyView.alternateSelectedImage,    forState: .Selected)
-            
-        case .Done:
-            self.setBackgroundImage(KeyView.doneNormalImage,      forState: .Normal)
-            self.setBackgroundImage(KeyView.doneHighlightedImage, forState: .Highlighted)
-            self.setBackgroundImage(KeyView.doneSelectedImage,    forState: .Selected)
         }
     }
     
@@ -184,32 +195,29 @@ public class KeyView: TintedButton {
     @objc private func touchCancelled(sender: UIButton) {
         self.targetable?.key(self, didChangeTrackingState: false)
     }
+}
+
+// ------------------------------------
+//  MARK: - KeyBackground Rendering -
+//
+private struct KeyBackground {
     
-    // ----------------------------------
-    //  MARK: - Normal Drawing -
-    //
-    private static var mainNormalImage      = KeyView.drawBackgroudImage(.Main,      state: .Normal)
-    private static var alternateNormalImage = KeyView.drawBackgroudImage(.Alternate, state: .Normal)
-    private static var doneNormalImage      = KeyView.drawBackgroudImage(.Done,      state: .Normal)
+    private static var images = [String : UIImage]()
     
-    // ----------------------------------
-    //  MARK: - Highlighted Drawing -
-    //
-    private static var mainHighlightedImage      = KeyView.drawBackgroudImage(.Main,      state: .Highlighted)
-    private static var alternateHighlightedImage = KeyView.drawBackgroudImage(.Alternate, state: .Highlighted)
-    private static var doneHighlightedImage      = KeyView.drawBackgroudImage(.Done,      state: .Highlighted)
+    private static func imageForColor(color: UIColor) -> UIImage {
+        let colorKey = color.key
+        if let image = self.images[colorKey] {
+            return image
+            
+        } else {
+            let image             = self.drawBackgroudImageWith(color)
+            self.images[colorKey] = image
+            
+            return image
+        }
+    }
     
-    // ----------------------------------
-    //  MARK: - Selected Drawing -
-    //
-    private static var mainSelectedImage      = KeyView.drawBackgroudImage(.Main,      state: .Selected)
-    private static var alternateSelectedImage = KeyView.drawBackgroudImage(.Alternate, state: .Selected)
-    private static var doneSelectedImage      = KeyView.drawBackgroudImage(.Done,      state: .Selected)
-    
-    // ----------------------------------
-    //  MARK: - Drawing Helper -
-    //
-    private static func drawBackgroudImage(style: KeyStyle, state: TrackingState) -> UIImage {
+    private static func drawBackgroudImageWith(color: UIColor) -> UIImage {
         
         let space  = CGFloat(3.0)
         let radius = CGFloat(6.0)
@@ -223,39 +231,6 @@ public class KeyView: TintedButton {
         let path       = UIBezierPath(roundedRect: rect.insetBy(dx: space + line * 0.5, dy: space + line * 0.5), cornerRadius: radius)
         path.lineWidth = line
         
-        /* ---------------------------------
-         ** Determine the color for this key
-         ** style and state.
-         */
-        let color: UIColor
-        switch state {
-        case .Normal:
-            
-            switch style {
-            case .Main:
-                color = Color.rgb(r: 255, g: 255, b: 255)
-            case .Alternate:
-                color = Color.rgb(r: 196, g: 204, b: 211)
-            case .Done:
-                color = Color.rgb(r:  70, g: 183, b: 204)
-            }
-            
-        case .Selected: fallthrough
-        case .Highlighted:
-            
-            switch style {
-            case .Main:
-                color = Color.rgb(r: 235, g: 235, b: 235)
-            case .Alternate:
-                color = Color.rgb(r:  70, g: 183, b: 204)//Color.rgb(r: 171, g: 180, b: 187)
-            case .Done:
-                color = Color.rgb(r:  48, g: 147, b: 166)
-            }
-        }
-        
-        /* ---------------------------------
-         ** Set and fill the key with color
-         */
         color.setFill()
         path.fill()
         
@@ -264,5 +239,34 @@ public class KeyView: TintedButton {
         UIGraphicsEndImageContext()
         
         return image
+    }
+}
+
+// ----------------------------------
+//  MARK: - UIControlState -
+//
+extension UIControlState {
+    var key: String {
+        return String(self.rawValue)
+    }
+}
+
+// ----------------------------------
+//  MARK: - UIColor -
+//
+extension UIColor {
+    var key: String {
+        let color      = self.CGColor
+        let count      = CGColorGetNumberOfComponents(color)
+        let components = CGColorGetComponents(color)
+        
+        var values = [String]()
+        for i in 0..<count {
+            let component = (components + i).memory
+            let rounded   = Int(component * 100.0)
+            values.append("\(rounded)")
+        }
+        
+        return values.joinWithSeparator(",")
     }
 }

--- a/KeyKit/KeyView.swift
+++ b/KeyKit/KeyView.swift
@@ -33,6 +33,14 @@ public class KeyView: TintedButton {
     public override static func initialize() {
         let proxy = KeyView.appearance()
         
+        // Key fonts
+        
+        let font = UIFont.systemFontOfSize(18.0)
+        
+        proxy.setTextFont(font, forStyle: .Main)
+        proxy.setTextFont(font, forStyle: .Alternate)
+        proxy.setTextFont(font, forStyle: .Done)
+        
         // Key colors
         
         let textDark  = Color.rgb(r:  50, g: 77,  b:  99)
@@ -69,13 +77,17 @@ public class KeyView: TintedButton {
     // ----------------------------------
     //  MARK: - UIAppearance -
     //
-    public dynamic var textFont: UIFont? {
-        get {
+    public dynamic func setTextFont(font: UIFont, forStyle style: KeyStyle) {
+        if self.key.style == style {
+            self.titleLabel?.font = font
+        }
+    }
+    
+    public dynamic func textFontForStyle(style: KeyStyle) -> UIFont? {
+        if self.key.style == style {
             return self.titleLabel?.font
         }
-        set {
-            self.titleLabel?.font = newValue
-        }
+        return nil
     }
     
     public dynamic func setTextColor(color: UIColor, forStyle style: KeyStyle, state: UIControlState) {

--- a/KeyKit/KeyView.swift
+++ b/KeyKit/KeyView.swift
@@ -14,7 +14,7 @@ public protocol KeyTargetable: class {
     func key(keyView: KeyView, didChangeTrackingState tracking: Bool)
 }
 
-public class KeyView: UIButton {
+public class KeyView: TintedButton {
 
     public enum TrackingState {
         case Normal
@@ -25,7 +25,54 @@ public class KeyView: UIButton {
     public let key: Key
     
     private weak var targetable: KeyTargetable?
-
+    
+    // ----------------------------------
+    //  MARK: - Default Styles -
+    //
+    public override static func initialize() {
+        let proxy = KeyView.appearance()
+        
+        let dark  = Color.rgb(r:  50, g: 77,  b:  99)
+        let light = Color.rgb(r: 121, g: 140, b: 156)
+        let alt   = Color.rgb(r: 255, g: 255, b: 255)
+        
+        proxy.setTextColor(light, forStyle: .Main,      state: .Normal)
+        proxy.setTextColor(dark,  forStyle: .Alternate, state: .Normal)
+        proxy.setTextColor(alt,   forStyle: .Done,      state: .Normal)
+        
+        proxy.setTextColor(light, forStyle: .Main,      state: .Highlighted)
+        proxy.setTextColor(alt,   forStyle: .Alternate, state: .Highlighted)
+        proxy.setTextColor(alt,   forStyle: .Done,      state: .Highlighted)
+        
+        proxy.setTextColor(light, forStyle: .Main,      state: .Selected)
+        proxy.setTextColor(alt,   forStyle: .Alternate, state: .Selected)
+        proxy.setTextColor(alt,   forStyle: .Done,      state: .Selected)
+    }
+    
+    // ----------------------------------
+    //  MARK: - UIAppearance -
+    //
+    public dynamic var textFont: UIFont? {
+        get {
+            return self.titleLabel?.font
+        }
+        set {
+            self.titleLabel?.font = newValue
+        }
+    }
+    
+    public dynamic func setTextColor(color: UIColor, forStyle style: KeyStyle, state: UIControlState) {
+        if self.key.style == style {
+            self.setTitleColor(color, forState: state)
+        }
+    }
+    
+    public dynamic func textColorForStyle(style: KeyStyle, state: UIControlState) -> UIColor? {
+        if self.key.style == style {
+            return self.titleColorForState(state)
+        }
+        return nil
+    }
     
     // ----------------------------------
     //  MARK: - Init -
@@ -55,20 +102,12 @@ public class KeyView: UIButton {
         self.setTitleShadowColor(UIColor.clearColor(), forState: .Normal)
         
         if let label = self.titleLabel {
-            label.font          = UIFont.boldSystemFontOfSize(18.0)
             label.textAlignment = .Center
             label.lineBreakMode = .ByClipping
             label.numberOfLines = 1
+        } else {
+            fatalError("Failed to configure KeyView label style. No titleLabel found.")
         }
-        
-        self.updateIconTintForState()
-        
-        /* ---------------------------------
-         ** Set text color for style
-         */
-        self.setTitleColor(self.titleColorForStyle(self.key.style, state: .Normal),      forState: .Normal)
-        self.setTitleColor(self.titleColorForStyle(self.key.style, state: .Highlighted), forState: .Highlighted)
-        self.setTitleColor(self.titleColorForStyle(self.key.style, state: .Selected),    forState: .Selected)
         
         /* ---------------------------------
          ** Set background image for style
@@ -105,35 +144,6 @@ public class KeyView: UIButton {
                 fatalError("KeyView failed to find image named: \(imageName).")
             }
         }
-    }
-    
-    // ----------------------------------
-    //  MARK: - State Update -
-    //
-    public override var highlighted: Bool {
-        didSet {
-            self.updateIconTintForState()
-        }
-    }
-    
-    public override var selected: Bool {
-        didSet {
-            self.updateIconTintForState()
-        }
-    }
-    
-    private func updateIconTintForState() {
-        let trackingState: TrackingState
-        
-        if self.state.contains(.Selected) {
-            trackingState = .Selected
-        } else if self.state.contains(.Highlighted) {
-            trackingState = .Highlighted
-        } else {
-            trackingState = .Normal
-        }
-        
-        self.tintColor = self.titleColorForStyle(self.key.style, state: trackingState)
     }
     
     // ----------------------------------
@@ -176,36 +186,6 @@ public class KeyView: UIButton {
     }
     
     // ----------------------------------
-    //  MARK: - Title Colors -
-    //
-    private func titleColorForStyle(style: Key.Style, state: TrackingState) -> UIColor {
-        switch state {
-        case .Normal:
-            
-            switch style {
-            case .Main:
-                return Color.rgb(r: 121, g: 140, b: 156)
-            case .Alternate:
-                return Color.rgb(r:  50, g: 77,  b:  99)
-            case .Done:
-                return Color.rgb(r: 255, g: 255, b: 255)
-            }
-            
-        case .Selected: fallthrough
-        case .Highlighted:
-            
-            switch style {
-            case .Main:
-                return Color.rgb(r: 121, g: 140, b: 156)
-            case .Alternate:
-                return Color.rgb(r: 255, g: 255, b: 255)
-            case .Done:
-                return Color.rgb(r: 255, g: 255, b: 255)
-            }
-        }
-    }
-    
-    // ----------------------------------
     //  MARK: - Normal Drawing -
     //
     private static var mainNormalImage      = KeyView.drawBackgroudImage(.Main,      state: .Normal)
@@ -229,7 +209,7 @@ public class KeyView: UIButton {
     // ----------------------------------
     //  MARK: - Drawing Helper -
     //
-    private static func drawBackgroudImage(style: Key.Style, state: TrackingState) -> UIImage {
+    private static func drawBackgroudImage(style: KeyStyle, state: TrackingState) -> UIImage {
         
         let space  = CGFloat(3.0)
         let radius = CGFloat(6.0)

--- a/KeyKit/KeyboardView.swift
+++ b/KeyKit/KeyboardView.swift
@@ -19,6 +19,26 @@ public class KeyboardView: UIView {
     private var trackingView: TrackingView!
     
     // ----------------------------------
+    //  MARK: - Default Styles -
+    //
+    public override static func initialize() {
+        let proxy = KeyboardView.appearance()
+        
+        proxy.setKeyboardColor(Color.rgb(r: 237, g: 240, b: 242))
+    }
+    
+    // ----------------------------------
+    //  MARK: - UIAppearance -
+    //
+    public dynamic func setKeyboardColor(color: UIColor) {
+        self.backgroundColor = color
+    }
+    
+    public dynamic func keyboardColor() -> UIColor? {
+        return self.backgroundColor
+    }
+    
+    // ----------------------------------
     //  MARK: - Init -
     //
     public init(faceView: FaceView?) {

--- a/KeyKit/KeyboardViewController.swift
+++ b/KeyKit/KeyboardViewController.swift
@@ -68,7 +68,6 @@ public class KeyboardViewController: UIViewController {
         self.keyboardView                  = KeyboardView(faceView: nil)
         self.keyboardView.frame            = self.view.bounds
         self.keyboardView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-        self.keyboardView.backgroundColor  = Color.rgb(r: 237, g: 240, b: 242)
         
         self.changeFaceTo(self.initialFaceIdentifier, inProxy: self.documentProxy)
         

--- a/KeyKit/RowView.swift
+++ b/KeyKit/RowView.swift
@@ -58,7 +58,7 @@ public class RowView: UIView {
          ** style key, we'll pin it to edge.
          */
         let leftKey  = keyViews.first!
-        let pinLeft  = leftKey.key.style == Key.Style.Alternate
+        let pinLeft  = leftKey.key.style == .Alternate
         if pinLeft {
             let keyWidth = keyWidths.removeFirst()
             keyViews.removeFirst()
@@ -72,7 +72,7 @@ public class RowView: UIView {
          ** style key, we'll pin it to edge.
          */
         let rightKey = keyViews.last!
-        let pinRight = rightKey.key.style  == Key.Style.Alternate
+        let pinRight = rightKey.key.style  == .Alternate
         if pinRight {
             let keyWidth = keyWidths.removeLast()
             keyViews.removeLast()

--- a/KeyKit/TintedButton.swift
+++ b/KeyKit/TintedButton.swift
@@ -1,0 +1,39 @@
+//
+//  TintedButton.swift
+//  KeyKit
+//
+//  Created by Dima Bart on 2016-07-26.
+//  Copyright © 2016 Dima Bart. All rights reserved.
+//
+
+import UIKit
+
+public class TintedButton: UIButton {
+    
+    // ----------------------------------
+    //  MARK: - States -
+    //
+    public override var selected: Bool {
+        didSet {
+            self.updateTintForState()
+        }
+    }
+    
+    public override var highlighted: Bool {
+        didSet {
+            self.updateTintForState()
+        }
+    }
+    
+    public override func setTitleColor(color: UIColor?, forState state: UIControlState) {
+        super.setTitleColor(color, forState: state)
+        self.updateTintForState()
+    }
+    
+    // ----------------------------------
+    //  MARK: - Updates -
+    //
+    private func updateTintForState() {
+        self.tintColor = self.titleColorForState(self.state)
+    }
+}


### PR DESCRIPTION
### What this does
- adds `UIAppearance` support to `KeyView` and `KeyboardView`
  - ability to theme key backgrounds
  - ability to theme key fonts
  - ability to theme key colors
  - ability to theme keyboard background color
- add defaults values for appearance proxy methods
- moves `KeyView` tint-for-state logic into superclass
