### PR TITLE
Added ability to change the return key label based on UIReturnKeyType

### DIFF
--- a/KeyKit.xcodeproj/project.pbxproj
+++ b/KeyKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00E7E9B31D65F5AE00617772 /* UIReturnKeyType+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E7E9B21D65F5AE00617772 /* UIReturnKeyType+Description.swift */; };
 		9A0CD6911D12F4E900281ACE /* KeyKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0CD6901D12F4E900281ACE /* KeyKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9A0CD69C1D12F77500281ACE /* Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0CD6991D12F77500281ACE /* Key.swift */; };
 		9A0CD69D1D12F77500281ACE /* Row.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0CD69A1D12F77500281ACE /* Row.swift */; };
@@ -25,6 +26,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		00E7E9B21D65F5AE00617772 /* UIReturnKeyType+Description.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIReturnKeyType+Description.swift"; sourceTree = "<group>"; };
 		9A0CD68D1D12F4E900281ACE /* KeyKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KeyKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A0CD6901D12F4E900281ACE /* KeyKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyKit.h; sourceTree = "<group>"; };
 		9A0CD6921D12F4E900281ACE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 			isa = PBXGroup;
 			children = (
 				9A0CD6BF1D12F92900281ACE /* UIView+Extensions.swift */,
+				00E7E9B21D65F5AE00617772 /* UIReturnKeyType+Description.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -225,6 +228,7 @@
 				9A0CD6C21D12F99800281ACE /* KeyboardViewController.swift in Sources */,
 				9A0CD6BD1D12F90300281ACE /* KeyboardView.swift in Sources */,
 				9A0CD6BB1D12F90300281ACE /* RowView.swift in Sources */,
+				00E7E9B31D65F5AE00617772 /* UIReturnKeyType+Description.swift in Sources */,
 				9A2E3D011D1C05BE00BF6BC8 /* Color.swift in Sources */,
 				9A0CD6C01D12F92900281ACE /* UIView+Extensions.swift in Sources */,
 				9A0CD6BC1D12F90300281ACE /* FaceView.swift in Sources */,

--- a/KeyKit/Key.swift
+++ b/KeyKit/Key.swift
@@ -37,7 +37,7 @@ public struct Key: Equatable {
         case Char(String)
     }
     
-    public var label:  Label
+    public let label:  Label
     public let value:  Value
     public let length: Double
     public let style:  KeyStyle

--- a/KeyKit/Key.swift
+++ b/KeyKit/Key.swift
@@ -37,7 +37,7 @@ public struct Key: Equatable {
         case Char(String)
     }
     
-    public let label:  Label
+    public var label:  Label
     public let value:  Value
     public let length: Double
     public let style:  KeyStyle

--- a/KeyKit/KeyView.swift
+++ b/KeyKit/KeyView.swift
@@ -261,8 +261,8 @@ public class KeyView: TintedButton {
     // ----------------------------------
     //  MARK: - Mutations -
     //
-    private func setLabel(label: Key.Label) {
-        key.label = label
+    public func setKey(newKey: Key) {
+        key = newKey
         initLabel()
     }
 }
@@ -338,20 +338,5 @@ extension UIColor {
         }
         
         return values.joinWithSeparator(",")
-    }
-}
-
-// ----------------------------------
-//  MARK: - Return Key -
-//
-extension KeyView {
-
-    func styleForReturnKeyType(type: UIReturnKeyType) {
-        
-        guard key.value == Key.Value.Action(.Return) else {
-            return
-        }
-        
-        setLabel(.Char(type.description))
     }
 }

--- a/KeyKit/KeyView.swift
+++ b/KeyKit/KeyView.swift
@@ -26,7 +26,7 @@ public class KeyView: TintedButton {
     private(set) var isDown      = false
     private(set) var isRepeating = false
     
-    public let key: Key
+    private(set) public var key: Key
     
     public var repeatDelay:     Double = 0.3
     public var repeatFrequency: Double = 0.085
@@ -257,6 +257,14 @@ public class KeyView: TintedButton {
             block()
         }
     }
+    
+    // ----------------------------------
+    //  MARK: - Mutations -
+    //
+    private func setLabel(label: Key.Label) {
+        key.label = label
+        initLabel()
+    }
 }
 
 // ------------------------------------
@@ -330,5 +338,20 @@ extension UIColor {
         }
         
         return values.joinWithSeparator(",")
+    }
+}
+
+// ----------------------------------
+//  MARK: - Return Key -
+//
+extension KeyView {
+
+    func styleForReturnKeyType(type: UIReturnKeyType) {
+        
+        guard key.value == Key.Value.Action(.Return) else {
+            return
+        }
+        
+        setLabel(.Char(type.description))
     }
 }

--- a/KeyKit/KeyboardView.swift
+++ b/KeyKit/KeyboardView.swift
@@ -111,19 +111,4 @@ public class KeyboardView: UIView {
         }
         return results
     }
-    
-    // ----------------------------------
-    //  MARK: - Updates -
-    //
-    public func updateReturnKeysFor(type: UIReturnKeyType) {
-        
-        let returnKeys = keyViewsMatching {
-            $0.value == Key.Value.Action(.Return)
-        }
-        
-        for keyView in returnKeys {
-            keyView.styleForReturnKeyType(type)
-        }
-        
-    }
 }

--- a/KeyKit/KeyboardView.swift
+++ b/KeyKit/KeyboardView.swift
@@ -41,14 +41,11 @@ public class KeyboardView: UIView {
     // ----------------------------------
     //  MARK: - Init -
     //
-    public init(faceView: FaceView?) {
+    public init(faceView: FaceView) {
         super.init(frame: CGRectZero)
         
         self.initTrackingView()
-        
-        if let faceView = faceView {
-            self.setFaceView(faceView)
-        }
+        self.setFaceView(faceView)
     }
     
     required public init?(coder aDecoder: NSCoder) {
@@ -113,5 +110,20 @@ public class KeyboardView: UIView {
             }
         }
         return results
+    }
+    
+    // ----------------------------------
+    //  MARK: - Updates -
+    //
+    public func updateReturnKeysFor(type: UIReturnKeyType) {
+        
+        let returnKeys = keyViewsMatching {
+            $0.value == Key.Value.Action(.Return)
+        }
+        
+        for keyView in returnKeys {
+            keyView.styleForReturnKeyType(type)
+        }
+        
     }
 }

--- a/KeyKit/KeyboardViewController.swift
+++ b/KeyKit/KeyboardViewController.swift
@@ -27,13 +27,17 @@ public class KeyboardViewController: UIViewController {
     public weak var documentProxy: UITextDocumentProxy? {
         didSet {
             self.updateShiftStateIn(self.documentProxy)
+            self.updateReturnKeyState()
         }
     }
     
     public var usePeriodShortcut = true
     public var allowCapsLock     = false
     
-    private var keyboardView: KeyboardView!
+    private lazy var keyboardView: KeyboardView = {
+        let initialFace = self.faceFor(self.initialFaceIdentifier)
+        return KeyboardView(faceView: self.faceViewFor(initialFace))
+    }()
     
     private var shiftKeys:         [KeyView] = []
     private var shiftEnabled:      Bool = false
@@ -43,7 +47,7 @@ public class KeyboardViewController: UIViewController {
     
     private let faces: [String : Face]
     private let initialFaceIdentifier: String
-
+    
     // ----------------------------------
     //  MARK: - Init -
     //
@@ -65,11 +69,11 @@ public class KeyboardViewController: UIViewController {
     public override func loadView() {
         super.loadView()
         
-        self.keyboardView                  = KeyboardView(faceView: nil)
         self.keyboardView.frame            = self.view.bounds
         self.keyboardView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
         
-        self.changeFaceTo(self.initialFaceIdentifier, inProxy: self.documentProxy)
+        self.referenceShiftKeys()
+        self.updateShiftStateIn(self.documentProxy)
         
         self.view.addSubview(self.keyboardView)
     }
@@ -82,7 +86,7 @@ public class KeyboardViewController: UIViewController {
     }
     
     public func textDidChange(input: UITextInput?) {
-        
+        updateReturnKeyState()
     }
     
     // ----------------------------------
@@ -145,6 +149,12 @@ public class KeyboardViewController: UIViewController {
                 
                 self.setShiftEnabled(enable)
             }
+        }
+    }
+    
+    private func updateReturnKeyState() {
+        if let keyType = self.documentProxy?.returnKeyType {
+            self.keyboardView.updateReturnKeysFor(keyType)
         }
     }
     

--- a/KeyKit/KeyboardViewController.swift
+++ b/KeyKit/KeyboardViewController.swift
@@ -153,8 +153,21 @@ public class KeyboardViewController: UIViewController {
     }
     
     private func updateReturnKeyState() {
-        if let keyType = self.documentProxy?.returnKeyType {
-            self.keyboardView.updateReturnKeysFor(keyType)
+        
+        guard let keyType = self.documentProxy?.returnKeyType else {
+            return
+        }
+        
+        let returnKeys = self.keyboardView.keyViewsMatching {
+            $0.value == Key.Value.Action(.Return)
+        }
+            
+        for keyView in returnKeys {
+                
+            let oldKey = keyView.key
+            let newKey = Key(label: .Char(keyType.description) , value: oldKey.value, length: oldKey.length, style: oldKey.style)
+                
+            keyView.setKey(newKey)
         }
     }
     

--- a/KeyKit/UIReturnKeyType+Description.swift
+++ b/KeyKit/UIReturnKeyType+Description.swift
@@ -1,0 +1,42 @@
+//
+//  UIReturnKeyType+Description.swift
+//  KeyKit
+//
+//  Created by Jeffrey Deng on 2016-08-17.
+//  Copyright © 2016 Dima Bart. All rights reserved.
+//
+
+import UIKit
+
+extension UIReturnKeyType: CustomStringConvertible, CustomDebugStringConvertible {
+    public var description: String {
+        switch self {
+        case .Default:
+            return "return"
+        case .Go:
+            return "go"
+        case .Google:
+            return "google"
+        case .Join:
+            return "join"
+        case .Next:
+            return "next"
+        case .Route:
+            return "route"
+        case .Search:
+            return "search"
+        case .Send:
+            return "send"
+        case .Yahoo:
+            return "yahoo"
+        case .Done:
+            return "done"
+        case .EmergencyCall:
+            return "emergency call"
+        case .Continue:
+            return "continue"
+        }
+    }
+    
+    public var debugDescription: String { return description }
+}


### PR DESCRIPTION
#### What
- Made the necessary changes to allow `label` property`Key` to be mutable
  - this lets us change the label `return` to `send`, `next` etc. 
- Moved initializer of `KeyboardView` to a lazy initializer
  - General housekeeping, since the property is explicitly unwrapped it should be available even before `loadView` is called. 
  - Same goes for the `KeyboardView`'s face, it should be initialized on `init` if it is explicitly unwrapped
- Added convenience extension on UIReturnKeyType to vend descriptions of enum
- Added `updateReturnKeyState` that update the `KeyboardView` for a `UIReturnKeyType`
  - Since there is no delegate callback for when we enter a different text field, and there is no KVO for `returnKeyType` I have made calls to update the return key on `didSet` of the document proxy and `textDidChange`
    - This is called in the `didSet` of document proxy so we can handle the times when the keyboard is first loaded or switching between text fields from different environments
    - This is called in the `textDidChange` to handle the times when the user is switching between text fields in the same environment

@dbart01 @davidmuzi 
